### PR TITLE
Return form instead of form_id and set form instead of form_id

### DIFF
--- a/src/JContainers/src/api_3/tes_string.h
+++ b/src/JContainers/src/api_3/tes_string.h
@@ -4,10 +4,12 @@
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/uuid/random_generator.hpp>
 
+#include "forms/form_observer.h"
 #include "tes_object.h"
 #include "collections/collections_types.h"
 #include "collections/context.h"
 #include "util/util.h"
+#include "domains/domain_master.h"
 #include "util/stl_ext.h"
 
 #include "RE/B/BSCoreTypes.h"
@@ -53,19 +55,21 @@ Accepts ASCII and UTF-8 encoded strings only");
 
         static UInt32 decodeFormStringToFormId(const char* form_string) {
             JC_LOG_API ("%s", form_string);
-            return decodeFormStringToForm(form_string);
+            return decodeFormStringToForm(form_string).get();
         }
-        static RE::FormID decodeFormStringToForm (const char* form_string) {
+        static forms::form_ref decodeFormStringToForm (const char* form_string) {
             JC_LOG_API ("%s", form_string);
-            return forms::string_to_form (form_string).value_or (0);
+            auto id = forms::string_to_form (form_string);
+            return forms::form_ref(id.value_or (0), domain_master::master::instance().get_form_observer());
         }
-        static skse::string_ref encodeFormToString (RE::FormID id) {
-            JC_LOG_API ("0x%x", id);
-            return skse::string_ref { skse::string_ref(forms::form_to_string (id).value_or ("").c_str()) };
+        static skse::string_ref encodeFormToString (const forms::form_ref &form) {
+            JC_LOG_API ("0x%x", form.get());
+            return skse::string_ref(forms::form_to_string (form.get()).value_or ("").c_str());
         }
         static skse::string_ref encodeFormIdToString(UInt32 id) {
             JC_LOG_API ("0x%x", id);
-            return encodeFormToString( util::to_enum<RE::FormID>(id) );
+            auto form = forms::form_ref(id, domain_master::master::instance().get_form_observer());
+            return encodeFormToString( form );
         }
 
         REGISTERF2_STATELESS(decodeFormStringToFormId, "formString", "FormId|Form <-> \"__formData|<pluginName>|<lowFormId>\"-string converisons");

--- a/src/JContainers/src/collections/bind_traits.h
+++ b/src/JContainers/src/collections/bind_traits.h
@@ -5,7 +5,9 @@
 #include "collections.h"
 #include "context.h"
 #include <SKSE/SKSE.h>
+#include <RE/T/TESForm.h>
 #include "skse/jc_skse.h"
+#include "domains/domain_master.h"
 
 namespace reflection { namespace binding {
 
@@ -43,19 +45,6 @@ namespace reflection { namespace binding {
 
     //////////////////////////////////////////////////////////////////////////
 
-    template<> struct GetConv < FormId > {
-        typedef RE::TESForm* tes_type;
-        static RE::TESForm* convert2Tes(FormId id) {
-            return RE::TESForm::LookupByID((uint32_t)id);
-        }
-        template<class Any>
-        static FormId convert2J(const RE::TESForm* form, const Any&) {
-            return form ? (FormId)form->formID : FormId::Zero;
-        }
-    };
-
-    /////////////////
-
     template<> struct GetConv < forms::form_ref > {
         typedef RE::TESForm* tes_type;
         static RE::TESForm* convert2Tes(const forms::form_ref& id) {
@@ -63,6 +52,10 @@ namespace reflection { namespace binding {
         }
         static forms::form_ref convert2J(const RE::TESForm* form, tes_context& ctx) {
             return make_weak_form_id(form, ctx);
+        }
+        template<class Any>
+        static const forms::form_ref convert2J(const RE::TESForm* form, const Any&) {
+            return forms::form_ref(form->GetFormID(), domain_master::master::instance().get_form_observer());
         }
     };
 

--- a/src/JContainers/src/reflection/tes_binding.h
+++ b/src/JContainers/src/reflection/tes_binding.h
@@ -291,7 +291,7 @@ namespace reflection { namespace binding {
                                 }
                                 return;    // OK for void
                             }
-                            else
+                            else // callback has non-void return value
                             {
                                 if constexpr (std::is_same_v<State, no_state>) {
                                     return GetConv<R>::convert2Tes(


### PR DESCRIPTION
in tes_string.

Remove handling of unused FormId in bind_traits
Add form_ref handling for state / tags expressively for the const return case of forms.